### PR TITLE
Add Contentful import scripts for the BSO archive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,11 @@ license.txt
 _site/
 .sass-cache/
 .jekyll-metadata
+
+# Contentful import -- credentials. This repo is public; never commit a token.
+*cma-token*
+.contentful-cma-token
+# derived/regenerable artifacts from scripts/contentful
+scripts/contentful/bso-graph.json
+scripts/contentful/import-state.json
+scripts/contentful/*.log

--- a/scripts/contentful/README.md
+++ b/scripts/contentful/README.md
@@ -1,0 +1,120 @@
+# BSO Archive → Contentful
+
+Imports `Wikipedia BSO Archive.xlsx` (repo root) into the Contentful space
+`3iiyvj5u5c9h`, environment `master`.
+
+Two steps: parse the spreadsheet into a normalized entity graph, then push that
+graph to the Contentful Management API.
+
+## Usage
+
+```bash
+# 1. parse the spreadsheet -> scripts/contentful/bso-graph.json
+python3 -m venv /tmp/bso && /tmp/bso/bin/pip install -q openpyxl
+/tmp/bso/bin/python scripts/contentful/parse_archive.py "Wikipedia BSO Archive.xlsx"
+
+# 2. review what would change -- writes nothing
+python3 scripts/contentful/import_to_contentful.py --dry-run
+
+# 3. create/update entries as DRAFTS
+python3 scripts/contentful/import_to_contentful.py
+
+# 4. publish (separate on purpose -- unpublishing thousands of entries is painful)
+python3 scripts/contentful/import_to_contentful.py --publish
+```
+
+Step 1 needs `openpyxl`. Steps 2–4 are stdlib only.
+
+### Credentials
+
+A Content Management token (`CFPAT-...`), from Contentful → Settings → API keys
+→ Content management tokens. **Not** a Delivery/Preview key — those are
+read-only and fail on the first write. Resolved in this order:
+
+1. `CONTENTFUL_CMA_TOKEN` env var
+2. `--token-file PATH`
+3. `~/.contentful-cma-token`
+
+Never commit the token. `.gitignore` covers the usual filenames, but this repo
+is a public GitHub Pages site, so treat a leaked token as compromised and
+rotate it.
+
+Space and environment can be overridden with `CONTENTFUL_SPACE_ID` and
+`CONTENTFUL_ENVIRONMENT_ID`.
+
+## Safety properties
+
+* **Idempotent.** Entry ids are derived from the content, so re-running updates
+  in place rather than duplicating. `import-state.json` also lets an
+  interrupted run resume.
+* **Existing entries are matched, not duplicated.** Composers, soloists and
+  conductors match on a name key that ignores accents and nobiliary particles,
+  so the sheet's `van Beethoven, Ludwig` resolves to an existing `Beethoven`.
+  Works match on (composer, title); concerts on date.
+* **Never overwrites a non-empty field.** Values are only written where the
+  existing field is empty, so hand-curated data (movement lists, composer
+  birth/death dates) survives a re-import. Where the sheet disagrees with a
+  populated field, the existing value wins and the difference is printed under
+  `CONFLICTS`.
+  The one deliberate exception is `concert.program`, listed in `OVERRIDE`.
+* **Drafts first.** Publishing is a separate flag, and runs in dependency order
+  so links always resolve.
+
+## Sheet conventions the parser relies on
+
+Verified against the source; these are what make the 1,489 rows parseable:
+
+* `SEASON n` in column A starts a season, `SEASON n, cont.` continues it.
+* A non-empty column A that isn't a season header starts a new concert.
+* **Leading whitespace means "continues the row above."** Wrapped piece titles
+  and extra soloist credits are indented.
+* A row with no piece and no composer carries **additional soloists for the
+  piece above** — 232 rows do this.
+* A *dated* row with no piece and no composer is an **additional performance of
+  the preceding program** (a two-night run), not a new program. Both concerts
+  link the same program items. 4 rows do this.
+* Each soloist cell holds exactly one credit, `Name` or `Name, Role[, Role...]`.
+  Multiple roles mean one player on several instruments. Roles that aren't
+  instruments or voices are treated as opera characters.
+
+## Known gaps
+
+* **Genre is inferred from the title** by keyword and covers ~68% of works. The
+  rest are left unset rather than guessed.
+* **Composer birth/death dates are not in the spreadsheet.** Only the handful
+  curated by hand have them.
+* **Opera casts are only partly modeled.** A single performer's role lands in
+  `programItem.character`; a full cast keeps its per-singer roles in the
+  verbatim `credits` array, since one field can't hold six. Lossless as text,
+  but not queryable. A `credit` join type would fix it.
+* Three concerts have no usable date (`unknown`, `May, 1981 (date n/a)`,
+  `var. dates, 1983`); the raw text is preserved in `concert.dateNote`.
+* **Rows 912–913 (Dec 13 2008) are ambiguous in the source and the parser makes
+  a judgment call.** Both rows give the same date, piece, composer, conductor
+  and orchestra, but *different venues* — `Grand Street Campus High Schools`
+  vs `Church of St. Ann & the Holy Trinity`. Only row 913 has the remaining two
+  pieces beneath it.
+  `duplicate_header()` treats row 912 as a superseded edit and skips it, which
+  matches how the entry was resolved in Contentful. The cost: `Grand Street
+  Campus High Schools` appears nowhere else in the archive, so that venue is no
+  longer referenced by any concert (the `hall` entry still exists, orphaned).
+  If the two rows are in fact one program performed at two venues on one day,
+  delete `duplicate_header` and instead give row 912 a `shares`-style link to
+  row 913's program. Check the season programs before assuming either way.
+
+## Content model
+
+```
+concert ──┬─ season
+          ├─ hall
+          ├─ orchestra[]
+          ├─ conductor
+          └─ program[] ─→ programItem ──┬─ work ──┬─ composer
+                                        │         └─ genre
+                                        ├─ composer      (when no work is named)
+                                        └─ soloists[] ─→ soloist | ensemble
+```
+
+`programItem` is what makes the archive queryable: it records a work *as
+performed on one occasion*, so the soloists attach to the specific piece they
+played. A flat `program` array of works and soloists cannot express that.

--- a/scripts/contentful/import_to_contentful.py
+++ b/scripts/contentful/import_to_contentful.py
@@ -1,0 +1,382 @@
+#!/usr/bin/env python3
+"""Import bso-graph.json into Contentful. Stdlib only.
+
+    export CONTENTFUL_CMA_TOKEN=cfpat-...
+    python3 import_to_contentful.py --dry-run     # report, write nothing
+    python3 import_to_contentful.py               # create/update drafts
+    python3 import_to_contentful.py --publish     # publish everything after
+
+Safety properties:
+  * Deterministic entry ids -> re-running updates instead of duplicating.
+  * Existing entries are matched by normalized name/date, so the 33 hand-curated
+    entries are reused rather than duplicated.
+  * MERGE semantics: a value is only written into a field that is currently
+    empty. Curated data (movement lists, composer birth/death dates) is never
+    overwritten. The sole exception is concert.program, which is deliberately
+    migrated from the old flat Work+Soloist list to ProgramItem links.
+  * Entries are created as drafts; publishing is a separate opt-in pass.
+"""
+import json, os, sys, time, urllib.request, urllib.error, unicodedata, re, collections
+from pathlib import Path
+
+SPACE = os.environ.get("CONTENTFUL_SPACE_ID", "3iiyvj5u5c9h")
+ENV = os.environ.get("CONTENTFUL_ENVIRONMENT_ID", "master")
+
+def _read_token():
+    """CONTENTFUL_CMA_TOKEN env var, else --token-file PATH, else
+    ~/.contentful-cma-token. A file keeps the token out of shell history and
+    out of this repo (which is public)."""
+    if os.environ.get("CONTENTFUL_CMA_TOKEN"):
+        return os.environ["CONTENTFUL_CMA_TOKEN"].strip()
+    if "--token-file" in sys.argv:
+        return Path(sys.argv[sys.argv.index("--token-file") + 1]).read_text().strip()
+    default = Path.home() / ".contentful-cma-token"
+    if default.exists():
+        return default.read_text().strip()
+    return None
+
+TOKEN = _read_token()
+LOCALE = os.environ.get("CONTENTFUL_LOCALE", "en-US")
+BASE = f"https://api.contentful.com/spaces/{SPACE}/environments/{ENV}"
+
+DRY = "--dry-run" in sys.argv
+DO_PUBLISH = "--publish" in sys.argv
+# --existing FILE : read the pre-existing entries from a local snapshot instead
+# of the CMA, so the dry run can be validated without a token.
+OFFLINE = None
+if "--existing" in sys.argv:
+    OFFLINE = Path(sys.argv[sys.argv.index("--existing") + 1])
+GRAPH = Path(__file__).parent / "bso-graph.json"
+STATE = Path(__file__).parent / "import-state.json"
+
+# concert.program is intentionally replaced: the old flat Work+Soloist array
+# cannot express which soloist played which piece.
+OVERRIDE = {("concert", "program")}
+
+# push order respects link dependencies
+ORDER = ["genre", "season", "orchestra", "hall", "conductor", "composer",
+         "soloist", "ensemble", "work", "programItem", "concert"]
+
+LINK_FIELDS = {   # field -> True if array of links
+    ("work", "composer"): False, ("work", "genre"): False,
+    ("programItem", "work"): False, ("programItem", "composer"): False,
+    ("programItem", "soloists"): True,
+    ("concert", "season"): False, ("concert", "hall"): False,
+    ("concert", "conductor"): False, ("concert", "orchestra"): True,
+    ("concert", "program"): True,
+}
+
+# ------------------------------------------------------------------ http
+
+class Http:
+    def __init__(self):
+        self.calls = 0
+        self.last = 0.0
+
+    def __call__(self, method, path, body=None, headers=None, ok404=False):
+        if not TOKEN:
+            sys.exit("CONTENTFUL_CMA_TOKEN is not set")
+        url = path if path.startswith("http") else BASE + path
+        data = json.dumps(body).encode() if body is not None else None
+        h = {"Authorization": f"Bearer {TOKEN}",
+             "Content-Type": "application/vnd.contentful.management.v1+json"}
+        h.update(headers or {})
+        for attempt in range(8):
+            gap = time.monotonic() - self.last
+            if gap < 0.16:                     # stay under ~6 req/s
+                time.sleep(0.16 - gap)
+            req = urllib.request.Request(url, data=data, headers=h, method=method)
+            try:
+                self.last = time.monotonic(); self.calls += 1
+                with urllib.request.urlopen(req, timeout=60) as r:
+                    return json.loads(r.read() or b"{}")
+            except urllib.error.HTTPError as e:
+                if e.code == 404 and ok404:
+                    return None
+                if e.code == 429:
+                    wait = float(e.headers.get("X-Contentful-RateLimit-Reset") or
+                                 e.headers.get("Retry-After") or 2 ** attempt)
+                    time.sleep(min(wait + 0.5, 30)); continue
+                if e.code >= 500:
+                    time.sleep(2 ** attempt); continue
+                raise RuntimeError(f"{method} {url} -> {e.code}: "
+                                   f"{e.read().decode()[:600]}") from None
+            except urllib.error.URLError:
+                time.sleep(2 ** attempt)
+        raise RuntimeError(f"{method} {url}: giving up after retries")
+
+http = Http()
+
+# ------------------------------------------------------------------ matching
+
+def strip_accents(s):
+    return "".join(c for c in unicodedata.normalize("NFKD", str(s))
+                   if not unicodedata.combining(c))
+
+def norm(s):
+    return re.sub(r"[^a-z0-9]+", " ", strip_accents(s).lower()).strip()
+
+PARTICLES = {"van","von","de","di","du","del","della","le","la","der","den","ten"}
+
+def name_key(first, last):
+    toks = [t for t in norm(f"{first or ''} {last or ''}").split()
+            if t and t not in PARTICLES]
+    return " ".join(sorted(toks))
+
+def val(fields, name):
+    v = (fields or {}).get(name)
+    if isinstance(v, dict):
+        return v.get(LOCALE)
+    return v
+
+def is_empty(v):
+    return v is None or v == "" or v == [] or v == {}
+
+_snap = json.loads(OFFLINE.read_text()) if OFFLINE else None
+
+def fetch_all(ctype):
+    if _snap is not None:
+        return [{"sys": {"id": e["id"], "version": 1},
+                 "fields": {k: {LOCALE: v} for k, v in e["fields"].items()}}
+                for e in _snap.get(ctype, [])]
+    out, skip = [], 0
+    while True:
+        r = http("GET", f"/entries?content_type={ctype}&limit=100&skip={skip}")
+        out.extend(r["items"])
+        skip += 100
+        if skip >= r["total"]:
+            return out
+
+def match_key(ctype, fields, composer_key_of=None):
+    f = fields
+    if ctype in ("composer", "conductor", "soloist"):
+        return name_key(val(f, "firstName"), val(f, "lastName"))
+    if ctype in ("orchestra", "hall", "genre", "ensemble"):
+        return norm(val(f, "name") or "")
+    if ctype == "season":
+        return val(f, "number")
+    if ctype == "work":
+        link = val(f, "composer")
+        cid = link["sys"]["id"] if isinstance(link, dict) and "sys" in link else None
+        return (composer_key_of.get(cid, "anon") if composer_key_of else "anon",
+                norm(val(f, "title") or ""))
+    if ctype == "concert":
+        return val(f, "date")
+    return None
+
+# ------------------------------------------------------------------ load graph
+
+graph = json.loads(GRAPH.read_text())
+T = graph["types"]
+
+print(f"space {SPACE} / env {ENV}    {'DRY RUN' if DRY else 'LIVE'}\n")
+print("reading existing entries...")
+
+existing = {}          # ctype -> {match_key: (id, fields, version)}
+by_id = {}             # id -> (ctype, fields)
+live_by_id = {}        # id -> (fields, version)   -- every entry already in the space
+for ct in ORDER:
+    items = fetch_all(ct)
+    existing[ct] = {}
+    for it in items:
+        by_id[it["sys"]["id"]] = (ct, it["fields"])
+        live_by_id[it["sys"]["id"]] = (it["fields"], it["sys"]["version"])
+    print(f"  {ct:12s} {len(items):4d} existing")
+    existing[ct]["__items__"] = items
+
+# composer id -> name key, needed to match works by (composer, title)
+composer_key_of = {it["sys"]["id"]: name_key(val(it["fields"], "firstName"),
+                                             val(it["fields"], "lastName"))
+                   for it in existing["composer"]["__items__"]}
+
+for ct in ORDER:
+    items = existing[ct].pop("__items__")
+    for it in items:
+        k = match_key(ct, it["fields"], composer_key_of)
+        if k is not None and k not in existing[ct]:
+            existing[ct][k] = (it["sys"]["id"], it["fields"], it["sys"]["version"])
+
+# ------------------------------------------------------------------ id remap
+
+def graph_match_key(ct, gid, rec):
+    if ct in ("composer", "conductor", "soloist"):
+        return name_key(rec.get("firstName"), rec.get("lastName"))
+    if ct in ("orchestra", "hall", "genre", "ensemble"):
+        return norm(rec.get("name") or "")
+    if ct == "season":
+        return rec.get("number")
+    if ct == "work":
+        cid = rec.get("composer")
+        ck = "anon"
+        if cid:
+            c = T["composer"].get(cid)
+            if c:
+                ck = name_key(c.get("firstName"), c.get("lastName"))
+        return (ck, norm(rec.get("title") or ""))
+    if ct == "concert":
+        return rec.get("date")
+    return None
+
+remap, reused = {}, collections.Counter()
+claimed = set()        # an existing entry may be claimed by only one graph entry
+for ct in ORDER:
+    for gid, rec in T.get(ct, {}).items():
+        k = graph_match_key(ct, gid, rec)
+        hit = existing.get(ct, {}).get(k) if k is not None else None
+        if hit and hit[0] not in claimed:
+            remap[gid] = hit[0]
+            claimed.add(hit[0])
+            reused[ct] += 1
+        elif hit:
+            # two graph entries share a match key (e.g. two concerts on the same
+            # date). Letting both target one entry would make the second
+            # overwrite the first, so the loser keeps its own id.
+            print(f"  ! {ct} {gid} and {hit[0]} share match key {k!r}; "
+                  f"{gid} keeps its own id")
+
+def rid(gid):
+    return remap.get(gid, gid)
+
+# ------------------------------------------------------------------ payloads
+
+def link(gid):
+    return {"sys": {"type": "Link", "linkType": "Entry", "id": rid(gid)}}
+
+def build_fields(ct, rec):
+    out = {}
+    for k, v in rec.items():
+        if v is None or v == []:
+            continue
+        if (ct, k) in LINK_FIELDS:
+            if LINK_FIELDS[(ct, k)]:
+                # array-of-links field; the graph may hold a bare id (e.g.
+                # concert.orchestra is always a single orchestra)
+                ids = v if isinstance(v, list) else [v]
+                out[k] = [link(x) for x in ids]
+            else:
+                out[k] = link(v)
+        else:
+            out[k] = v
+    return out
+
+conflicts = []
+
+def describe(v):
+    """Render a field value (including links) for comparison/reporting."""
+    if isinstance(v, dict) and "sys" in v:
+        return label_of(v["sys"]["id"])
+    if isinstance(v, list):
+        return [describe(x) for x in v]
+    return v
+
+def label_of(eid):
+    """Human label for an entry id, from the graph or the existing entries."""
+    for ct in ORDER:
+        rec = T.get(ct, {}).get(eid)
+        if rec:
+            return (rec.get("title") or rec.get("name") or rec.get("label")
+                    or rec.get("abbreviation") or rec.get("fullName")
+                    or rec.get("lastName") or eid)
+    ct_f = by_id.get(eid)
+    if ct_f:
+        f = ct_f[1]
+        for k in ("title", "name", "label", "fullName", "lastName"):
+            if val(f, k):
+                return val(f, k)
+    return eid
+
+def merge(ct, target_id, new_fields):
+    """Return (payload_fields, version_or_None, action).
+    Only fills fields that are currently empty, except OVERRIDE fields."""
+    # look up by entry id, not by match key: program items and undated concerts
+    # have no match key, and without the current version an update PUT 409s.
+    cur, version = live_by_id.get(target_id, (None, None))
+    if cur is None:
+        return {k: {LOCALE: v} for k, v in new_fields.items()}, None, "create"
+
+    merged = dict(cur)
+    changed = []
+    for k, v in new_fields.items():
+        if (ct, k) in OVERRIDE:
+            if val(cur, k) != v:
+                merged[k] = {LOCALE: v}; changed.append(k + "*")
+        elif is_empty(val(cur, k)):
+            merged[k] = {LOCALE: v}; changed.append(k)
+        else:
+            # existing value kept; record where the sheet disagrees with it
+            old, new = val(cur, k), v
+            if describe(old) != describe(new):
+                conflicts.append((ct, target_id, k, describe(old), describe(new)))
+    if not changed:
+        return None, version, "unchanged"
+    return merged, version, "update:" + ",".join(changed)
+
+# ------------------------------------------------------------------ push
+
+plan = collections.Counter()
+detail = collections.defaultdict(list)
+state = json.loads(STATE.read_text()) if STATE.exists() else {"done": []}
+done = set(state["done"])
+
+for ct in ORDER:
+    recs = T.get(ct, {})
+    for gid, rec in recs.items():
+        target = rid(gid)
+        fields = build_fields(ct, rec)
+        payload, version, action = merge(ct, target, fields)
+        plan[f"{ct}:{action.split(':')[0]}"] += 1
+        if action.startswith("update"):
+            detail[ct].append(f"{target}  {action}")
+        if DRY or payload is None:
+            continue
+        key = f"{ct}/{target}"
+        if key in done:
+            continue
+        headers = {"X-Contentful-Content-Type": ct}
+        if version is not None:
+            headers["X-Contentful-Version"] = str(version)
+        http("PUT", f"/entries/{target}", {"fields": payload}, headers)
+        done.add(key)
+        if len(done) % 50 == 0:
+            STATE.write_text(json.dumps({"done": sorted(done)}))
+            print(f"    ... {len(done)} entries written")
+
+if not DRY:
+    STATE.write_text(json.dumps({"done": sorted(done)}))
+
+print("\n--- plan" if DRY else "\n--- result")
+for ct in ORDER:
+    row = {k.split(":")[1]: v for k, v in plan.items() if k.startswith(ct + ":")}
+    if row:
+        print(f"  {ct:12s} " + "  ".join(f"{k}={v}" for k, v in sorted(row.items())))
+print(f"\n  reused existing entries: {dict(reused)}")
+print(f"  http calls: {http.calls}")
+
+if detail:
+    print("\n--- updates to existing entries (fills empty fields; * = deliberate override)")
+    for ct, lines in detail.items():
+        for l in lines[:40]:
+            print(f"  {ct:12s} {l}")
+
+if conflicts:
+    print(f"\n--- CONFLICTS ({len(conflicts)}): existing value kept, sheet disagrees")
+    for ct, eid, field, old, new in conflicts:
+        print(f"  {ct}.{field}  {eid}\n      kept  : {old!r}\n      sheet : {new!r}")
+
+if DO_PUBLISH and not DRY:
+    print("\npublishing...")
+    n = 0
+    for ct in ORDER:
+        for gid in T.get(ct, {}):
+            e = http("GET", f"/entries/{rid(gid)}", ok404=True)
+            if not e:
+                continue
+            try:
+                http("PUT", f"/entries/{rid(gid)}/published", None,
+                     {"X-Contentful-Version": str(e["sys"]["version"])})
+                n += 1
+            except RuntimeError as err:
+                print(f"  publish failed {ct}/{rid(gid)}: {str(err)[:200]}")
+    print(f"  published {n}")
+
+print("\ndone" + (" (nothing written -- dry run)" if DRY else ""))

--- a/scripts/contentful/parse_archive.py
+++ b/scripts/contentful/parse_archive.py
@@ -1,0 +1,475 @@
+#!/usr/bin/env python3
+"""Parse 'Wikipedia BSO Archive.xlsx' into a normalized entity graph for Contentful.
+
+Emits bso-graph.json: entity tables keyed by deterministic Contentful entry id,
+plus a report of anything the parser could not confidently interpret.
+
+Sheet conventions this relies on (verified against the source):
+  - 'SEASON n' in col A starts a season; 'SEASON n, cont.' continues it.
+  - A non-empty col A that isn't a season header starts a new concert.
+  - Leading whitespace in the Piece cell means the text continues the item above.
+  - A row with no Piece and no Composer carries extra soloist credits for the
+    item above.
+"""
+import json, re, sys, hashlib, unicodedata, datetime, collections
+from pathlib import Path
+
+import openpyxl
+
+SRC = Path(sys.argv[1] if len(sys.argv) > 1 else "Wikipedia BSO Archive.xlsx")
+OUT = Path(__file__).parent / "bso-graph.json"
+
+# ---------------------------------------------------------------- helpers
+
+def strip_accents(s):
+    return "".join(c for c in unicodedata.normalize("NFKD", s)
+                   if not unicodedata.combining(c))
+
+def slugify(s, maxlen=40):
+    s = strip_accents(str(s)).lower()
+    s = re.sub(r"[^a-z0-9]+", "-", s).strip("-")
+    return s[:maxlen].strip("-") or "x"
+
+def h6(s):
+    return hashlib.sha1(str(s).encode("utf-8")).hexdigest()[:6]
+
+def norm(s):
+    """Aggressive normalization for duplicate detection."""
+    s = strip_accents(str(s)).lower()
+    return re.sub(r"[^a-z0-9]+", " ", s).strip()
+
+PARTICLES = {"van", "von", "de", "di", "du", "del", "della", "le", "la", "der", "den", "ten"}
+
+def name_key(first, last):
+    """Match key that ignores nobiliary particles, so 'van Beethoven, Ludwig'
+    and an existing entry stored as first='Ludwig' last='Beethoven' collide."""
+    toks = [t for t in norm(f"{first} {last}").split() if t and t not in PARTICLES]
+    return " ".join(sorted(toks))
+
+BLANK = {"", "unknown", "none", "n/a", "na", "various", "tbd"}
+def is_blank(v):
+    return v is None or str(v).strip().lower() in BLANK
+
+# instrument/voice/role values allowed by the soloist.instrument enum
+ENUM = ["Violin","Viola","Violoncello","Double Bass","Flute","Oboe","Clarinet","Bassoon",
+        "French Horn","Trumpet","Trombone","Tuba","Percussion","Harp","Piano","Saxophone",
+        "Alto Saxophone","Harpsichord","Guitar","Accordion","Marimba","Vibraphone","Xylophone",
+        "Timpani","Drums","Basso Continuo","Soprano","Mezzo-Soprano","Contralto","Alto",
+        "Tenor","Baritone","Bass","Director","Narrator","Soloist"]
+# sheet spelling -> canonical enum value (keeps us off duplicate instruments)
+ALIAS = {"cello": "Violoncello", "violincello": "Violoncello", "horn": "French Horn",
+         "accordian": "Accordion", "french horn": "French Horn", "contrabass": "Double Bass",
+         "mezzo soprano": "Mezzo-Soprano", "mezzo-soprano": "Mezzo-Soprano"}
+ENUM_LOOKUP = {norm(v): v for v in ENUM}
+ENUM_LOOKUP.update({norm(k): v for k, v in ALIAS.items()})
+
+ENSEMBLE_RX = re.compile(
+    r"chorus|choir|chorale|choralettes|ensemble|quintet|quartet|sextet|trio|octet|"
+    r"orchestra|philharmonia|band|players|singers|company|community sing|society",
+    re.I)
+# groups whose names carry none of the keywords above
+ENSEMBLE_NAMES = {"spiritus et anima", "the nancy beth falloon waltzers"}
+
+def ensemble_kind(name):
+    n = name.lower()
+    if "chorale" in n or "chorus" in n or "choral" in n: return "Chorus"
+    if "choir" in n: return "Choir"
+    if "brass" in n: return "Brass Ensemble"
+    if "percussion" in n: return "Percussion Ensemble"
+    if re.search(r"quintet|quartet|sextet|trio|octet|ensemble|players", n): return "Chamber Ensemble"
+    if "singers" in n: return "Vocal Group"
+    return "Other"
+
+# ordered: more specific patterns first
+GENRE_RX = [
+    ("Concerto Grosso", r"\bconcerto grosso\b"),
+    ("Symphony",        r"\bsymphon(y|ie|ia)\b|\bsinfoni"),
+    ("Concerto",        r"\bconcerto\b|\bconcertino\b"),
+    ("Overture",        r"\bovertur"),
+    ("Suite",           r"\bsuite\b"),
+    ("Mass",            r"\bmass\b|\brequiem\b|\bte deum\b|\bmagnificat\b"),
+    ("Cantata",         r"\bcantata\b|\boratorio\b"),
+    ("Variations",      r"\bvariations\b"),
+    ("Rhapsody",        r"\brhapsod"),
+    ("Fantasia",        r"\bfantas"),
+    ("Serenade",        r"\bserenade\b|\bdivertimento\b"),
+    ("Ballet",          r"\bballet\b"),
+    ("Tone Poem",       r"\btone poem\b|\bsymphonic poem\b"),
+    ("Prelude",         r"\bprelude\b|\bvorspiel\b"),
+    ("Waltz",           r"\bwaltz\b|\bvalse\b"),
+    ("March",           r"\bmarch\b"),
+    ("Sonata",          r"\bsonata\b"),
+    ("Aria",            r"\baria\b|,\s*from\b|\bfrom (the |la |der |das |le )?\w"),
+]
+
+KEY_RX = re.compile(r"\bin\s+([A-G](?:-flat|-sharp|b|#)?\s+(?:Major|Minor))\b", re.I)
+NICK_RX = re.compile(r'\("([^"]+)"\)')
+NOTE_RX = re.compile(r"world premiere|premiere|concert version|excerpts?|\bmvts?\b|"
+                     r"\bmovement\b|abridged|arr\.|orch\.", re.I)
+MONTHS = {m.lower(): i for i, m in enumerate(
+    ["Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"], 1)}
+
+def parse_date(v):
+    """-> (iso_date_or_None, note_or_None)"""
+    if isinstance(v, datetime.datetime):
+        return v.date().isoformat(), None
+    if isinstance(v, datetime.date):
+        return v.isoformat(), None
+    s = str(v).strip()
+    m = re.search(r"([A-Za-z]{3})\w*\.?\s+(\d{1,2}),?\s+(\d{4})", s)
+    if m and m.group(1).lower() in MONTHS:
+        try:
+            return datetime.date(int(m.group(3)), MONTHS[m.group(1).lower()],
+                                 int(m.group(2))).isoformat(), None
+        except ValueError:
+            pass
+    return None, s   # unparseable -> keep verbatim in dateNote
+
+# ---------------------------------------------------------------- id registry
+
+class Registry:
+    """Allocates stable, collision-free entry ids and dedupes by match key."""
+    def __init__(self):
+        self.tables = collections.defaultdict(dict)   # type -> {id: fields}
+        self.by_key = {}                              # (type, key) -> id
+        self.used = set()
+
+    def _uniq(self, base):
+        cid, n = base, 2
+        while cid in self.used:
+            cid = f"{base[:60]}-{n}"; n += 1
+        self.used.add(cid)
+        return cid
+
+    def get(self, ctype, key, id_base, build):
+        """Return existing id for key, else allocate one and build the fields."""
+        k = (ctype, key)
+        if k in self.by_key:
+            return self.by_key[k]
+        cid = self._uniq(id_base)
+        self.by_key[k] = cid
+        self.tables[ctype][cid] = build()
+        return cid
+
+R = Registry()
+report = collections.defaultdict(list)
+
+# ---------------------------------------------------------------- entity builders
+
+def get_composer(raw):
+    """'van Beethoven, Ludwig' -> composer id. Returns None for blanks."""
+    s = re.sub(r"\s+", " ", str(raw)).strip().rstrip(",")
+    if is_blank(s):
+        return None
+    if "," in s:
+        last, first = s.split(",", 1)
+        last, first = last.strip(), first.strip()
+    else:
+        last, first = s, ""          # 'Traditional', 'English Carol (arr. ...)'
+    return R.get("composer", name_key(first, last),
+                 f"cmp-{slugify(last + '-' + first)}",
+                 lambda: {"firstName": first or None, "lastName": last,
+                          "sortName": s, "dateOfBirth": None, "dateOfDeath": None})
+
+def get_conductor(raw):
+    s = re.sub(r"\s+", " ", str(raw)).strip()
+    if is_blank(s):
+        return None
+    parts = s.split()
+    first, last = " ".join(parts[:-1]), parts[-1]
+    return R.get("conductor", name_key(first, last), f"cnd-{slugify(s)}",
+                 lambda: {"firstName": first or None, "lastName": last})
+
+ORCH_NAMES = {"BSO": "Brooklyn Symphony Orchestra",
+              "BHO": "Brooklyn Heights Orchestra",
+              "BHMS": "Brooklyn Heights Music Society"}
+
+def get_orchestra(raw):
+    if is_blank(raw):
+        return None
+    ab = str(raw).strip().upper()
+    name = ORCH_NAMES.get(ab, str(raw).strip())
+    return R.get("orchestra", norm(name), f"orc-{slugify(ab)}",
+                 lambda: {"name": name, "abbreviation": ab})
+
+VENUE_FIX = {"brooklyn musuem of art": "Brooklyn Museum of Art"}
+
+def get_hall(raw):
+    if is_blank(raw) or "not available" in str(raw).lower():
+        return None
+    s = re.sub(r"\s+", " ", str(raw)).strip()
+    s = VENUE_FIX.get(norm(s), s)
+    # existing entries follow 'Walt Whitman Hall' + location 'Brooklyn College'
+    if "," in s:
+        name, loc = s.split(",", 1)
+        name, loc = name.strip(), loc.strip()
+    else:
+        name, loc = s, None
+    return R.get("hall", norm(name), f"hal-{slugify(name)}",
+                 lambda: {"name": name, "location": loc, "slug": slugify(name, 60)})
+
+def get_genre(name):
+    return R.get("genre", norm(name), f"gen-{slugify(name)}", lambda: {"name": name})
+
+def get_season(num, notes):
+    return R.get("season", num, f"sea-{num}",
+                 lambda: {"number": num, "label": f"Season {num}",
+                          "notes": notes or None})
+
+def get_work(title, composer_id, composer_raw):
+    title = re.sub(r"\s+", " ", str(title)).strip()
+    ckey = composer_id or "anon"
+    key = (ckey, norm(title))
+    def build():
+        km = KEY_RX.search(title)
+        nm = NICK_RX.search(title)
+        genre_id = None
+        for gname, rx in GENRE_RX:
+            if re.search(rx, title, re.I):
+                genre_id = get_genre(gname)
+                break
+        return {"title": title,
+                "slug": f"{slugify(composer_raw or 'anon', 24)}--{slugify(title, 34)}-{h6(key)}",
+                "musicalKey": km.group(1).title() if km else None,
+                "nickname": nm.group(1) if nm else None,
+                "composer": composer_id,
+                "genre": genre_id,
+                "movement": None}
+    return R.get("work", key, f"wrk-{slugify(title, 30)}-{h6(key)}", build)
+
+def get_performer(credit):
+    """One credit string -> (performer_id, credit_kind, character_or_None).
+
+    A credit is 'Name' or 'Name, Role[, Role...]'. Multiple roles mean one
+    player covering several instruments ('Bill Utley, Tabla, Temple Blocks,
+    Drums'). Roles that aren't instruments/voices are opera characters.
+    """
+    s = re.sub(r"\s+", " ", str(credit)).strip().rstrip(",;")
+    if is_blank(s) or s.endswith(":"):
+        return None, None, None
+    if s.lower().startswith("with "):          # stage direction, not a performer
+        return None, None, None
+
+    segs = [p.strip() for p in s.split(",") if p.strip()]
+    name, roles = segs[0], segs[1:]
+
+    if ENSEMBLE_RX.search(name) or norm(name) in ENSEMBLE_NAMES:
+        return (R.get("ensemble", norm(name), f"ens-{slugify(name)}",
+                      lambda: {"name": name, "kind": ensemble_kind(name)}),
+                "ensemble", None)
+    if not re.match(r"^[A-Z]", name) or len(name.split()) > 5:
+        return None, None, None                 # not a personal name
+
+    enum_vals = [ENUM_LOOKUP[norm(r)] for r in roles if norm(r) in ENUM_LOOKUP]
+    others = [r for r in roles if norm(r) not in ENUM_LOOKUP]
+    parts = name.split()
+    first, last = " ".join(parts[:-1]), parts[-1]
+    pid = R.get("soloist", name_key(first, last), f"sol-{slugify(name)}",
+                lambda: {"firstName": first or None, "lastName": last,
+                         "fullName": name, "instrument": None})
+    # a person seen again with new instruments accumulates them
+    rec = R.tables["soloist"][pid]
+    if enum_vals:
+        rec["instrument"] = sorted(set((rec.get("instrument") or []) + enum_vals))
+    return pid, "soloist", (others[0] if others else None)
+
+def split_credits(raw):
+    """The sheet puts exactly one credit per cell -- verified: no cell uses
+    ';', ' and ', or a newline as a separator, and the only ' & ' is inside
+    the ensemble name 'Grace & Spiritus Chorale of Brooklyn'."""
+    s = str(raw).strip()
+    return [s] if s else []
+
+# ---------------------------------------------------------------- main sweep
+
+wb = openpyxl.load_workbook(SRC, data_only=True)
+ws = wb["ARCHIVE"]
+
+concerts = []          # ordered list of concert dicts
+season_num, season_notes = None, None
+cur = None             # current concert
+cur_item = None        # current program item
+
+sheet = list(ws.iter_rows(min_row=6, values_only=True))
+
+def duplicate_header(i):
+    """True if row i starts a concert that the very next row restates.
+
+    The source has at least one such artifact (rows 912-913: the same date and
+    the same opening piece, once as a date cell and once as text). Honoring both
+    would emit a phantom concert holding only that first piece.
+    """
+    a, piece = (list(sheet[i]) + [None] * 7)[:2]
+    if a in (None, "") or i + 1 >= len(sheet):
+        return False
+    b, piece2 = (list(sheet[i + 1]) + [None] * 7)[:2]
+    if b in (None, ""):
+        return False
+    if isinstance(b, str) and b.strip().upper().startswith("SEASON"):
+        return False
+    same_date = parse_date(a)[0] is not None and parse_date(a)[0] == parse_date(b)[0]
+    same_piece = (str(piece or "").strip().lower() == str(piece2 or "").strip().lower()
+                  and str(piece or "").strip() != "")
+    return same_date and same_piece
+
+for i, row in enumerate(sheet):
+    rn = i + 6
+    a, piece, sol, comp, cond, orch, ven = (list(row) + [None] * 7)[:7]
+    if all(v in (None, "") for v in (a, piece, sol, comp, cond, orch, ven)):
+        continue
+    if duplicate_header(i):
+        report["duplicate_concert_row"].append(f"row {rn}: {a!r} restated by row {rn+1}")
+        continue
+
+    # -- season header
+    if isinstance(a, str) and a.strip().upper().startswith("SEASON"):
+        m = re.match(r"SEASON\s+(\d+)", a.strip(), re.I)
+        if m:
+            n = int(m.group(1))
+            extra = a.strip()[m.end():].strip(" ,-")
+            if n != season_num:
+                season_num, season_notes = n, (extra if extra.lower() != "cont." else None)
+            elif extra and extra.lower() != "cont.":
+                season_notes = ((season_notes + " ") if season_notes else "") + extra
+            sid = get_season(season_num, season_notes)
+            # a later header for the same season can carry the note (e.g. the
+            # COVID cancellation on the second 'SEASON 47' row)
+            if season_notes:
+                R.tables["season"][sid]["notes"] = season_notes
+        continue
+
+    # -- new concert
+    if a not in (None, ""):
+        iso, note = parse_date(a)
+        prev = cur
+        # A dated row carrying neither piece nor composer is an additional
+        # performance of the preceding program (a two-night run), not a new
+        # program. It shares that concert's program items so the cast listed
+        # beneath it lands on the right pieces.
+        shares = (prev is not None and prev["items"]
+                  and is_blank(comp)
+                  and not (piece is not None and str(piece).strip()))
+        cur = {"date": iso, "dateNote": note, "season": season_num,
+               "hall": get_hall(ven) or (prev["hall"] if shares else None),
+               "orchestra": get_orchestra(orch) or (prev["orchestra"] if shares else None),
+               "conductor": get_conductor(cond) or (prev["conductor"] if shares else None),
+               "items": prev["items"] if shares else [],
+               "shared": shares,
+               "raw_date": str(a).strip(), "raw_venue": ven, "row": rn}
+        if shares:
+            cur["dateNote"] = note or f"Additional performance of the {prev['date'] or prev['raw_date']} program"
+            cur_item = prev["items"][-1]      # cast below continues on this item
+            report["shared_program"].append(
+                f"row {rn}: {a!r} shares the program of {prev['date'] or prev['raw_date']!r}")
+        else:
+            cur_item = None
+        concerts.append(cur)
+        if note:
+            report["unparseable_date"].append(f"row {rn}: {a!r}")
+    if cur is None:
+        report["orphan_row"].append(f"row {rn}: {piece!r}")
+        continue
+
+    piece_s = str(piece) if piece is not None else ""
+    has_piece = piece_s.strip() != ""
+    # leading whitespace + no composer  =>  wrapped continuation of the item above
+    is_cont = has_piece and piece_s[:1].isspace() and is_blank(comp) and cur_item is not None
+
+    if is_cont:
+        cur_item["note"] = " ".join(filter(None, [cur_item.get("note"),
+                                                  piece_s.strip()]))[:255]
+    elif has_piece:
+        t = piece_s.strip()
+        if re.fullmatch(r"(works|records) not available", t, re.I):
+            cur_item = {"label": t, "work": None, "composer": get_composer(comp) if not is_blank(comp) else None,
+                        "soloists": [], "credits": [], "character": None, "note": t}
+            cur["items"].append(cur_item)
+        else:
+            cid = get_composer(comp)
+            wid = get_work(t, cid, comp)
+            nm = NOTE_RX.search(t)
+            cur_item = {"label": t[:255], "work": wid, "composer": None, "soloists": [],
+                        "credits": [], "character": None,
+                        "note": nm.group(0) if nm else None}
+            cur["items"].append(cur_item)
+    elif not is_blank(comp):
+        # composer named but no piece (Oct 26 1982 'works not available' block)
+        cid = get_composer(comp)
+        cur_item = {"label": f"{str(comp).strip()} — work not recorded"[:255],
+                    "work": None, "composer": cid, "soloists": [], "credits": [],
+                    "character": None, "note": "work not recorded"}
+        cur["items"].append(cur_item)
+
+    # -- soloist credits attach to the current item
+    if sol is not None and str(sol).strip():
+        if cur_item is None:
+            report["credit_without_item"].append(f"row {rn}: {sol!r}")
+        else:
+            for credit in split_credits(sol):
+                credit = credit.strip()
+                cur_item["credits"].append(credit)
+                pid, kind, char = get_performer(credit)
+                if pid:
+                    if pid not in cur_item["soloists"]:
+                        cur_item["soloists"].append(pid)
+                    # only meaningful for a single-performer item; a full opera
+                    # cast keeps its per-singer roles in `credits` instead
+                    if char:
+                        cur_item["character"] = (char if len(cur_item["credits"]) == 1
+                                                 else None)
+                elif not is_blank(credit):
+                    report["credit_not_linked"].append(f"row {rn}: {credit!r}")
+
+# ---------------------------------------------------------------- finalize concerts
+
+DOW = {0:"Mon",1:"Tue",2:"Wed",3:"Thu",4:"Fri",5:"Sat",6:"Sun"}
+seen_cid = collections.Counter()
+for c in concerts:
+    if c["date"]:
+        base = "cnc-" + c["date"].replace("-", "")
+    else:
+        base = f"cnc-s{c['season']}-{slugify(c['raw_date'], 20)}"
+    seen_cid[base] += 1
+    cid = base if seen_cid[base] == 1 else f"{base}-{seen_cid[base]}"
+    c["id"] = cid
+
+    orch_ab = (R.tables["orchestra"][c["orchestra"]]["abbreviation"]
+               if c["orchestra"] else None)
+    label = c["date"] or c["raw_date"]
+    c["title"] = " — ".join(filter(None, [label, orch_ab])) [:255]
+
+    if c["shared"]:
+        continue          # items already belong to (and are named by) the first date
+    for i, it in enumerate(c["items"], start=1):
+        it["order"] = i
+        it["id"] = f"pi-{cid[4:]}-{i}"
+
+# program items get their own table (shared items are written once)
+for c in concerts:
+    for it in c["items"]:
+        R.tables["programItem"][it["id"]] = {
+            k: it[k] for k in ("label","work","composer","soloists","credits",
+                               "character","order","note")}
+
+R.tables["concert"] = {c["id"]: {"title": c["title"], "date": c["date"],
+                                 "dateNote": c["dateNote"],
+                                 "season": f"sea-{c['season']}" if c["season"] else None,
+                                 "hall": c["hall"], "orchestra": c["orchestra"],
+                                 "conductor": c["conductor"],
+                                 "program": [it["id"] for it in c["items"]]}
+                       for c in concerts}
+
+graph = {"types": {t: R.tables[t] for t in sorted(R.tables)},
+         "report": {k: v for k, v in sorted(report.items())}}
+OUT.write_text(json.dumps(graph, indent=1, ensure_ascii=False))
+
+print(f"parsed {SRC.name}\n")
+for t in sorted(R.tables):
+    print(f"  {t:14s} {len(R.tables[t]):5d}")
+print(f"\n  {'TOTAL':14s} {sum(len(v) for v in R.tables.values()):5d} entries")
+print("\nreport:")
+for k, v in sorted(report.items()):
+    print(f"  {k}: {len(v)}")
+    for line in v[:6]:
+        print(f"     {line}")
+print(f"\nwrote {OUT}")


### PR DESCRIPTION
Imports "Wikipedia BSO Archive.xlsx" (52 seasons, 250 concerts) into the Contentful space as 2,383 linked entries.

parse_archive.py turns the sheet into a normalized entity graph. The sheet encodes structure through indentation and blank cells, so the parser relies on conventions verified against the source: leading whitespace continues the row above, a row with no piece and no composer carries extra soloists for the piece above (232 rows), and a dated row with neither is an additional performance of the preceding program rather than a new one (4 rows).

import_to_contentful.py pushes the graph to the CMA using stdlib only. It is idempotent via content-derived entry ids, matches pre-existing entries on accent- and particle-insensitive name keys so the sheet's "van Beethoven, Ludwig" resolves to an existing "Beethoven", and only ever writes into fields that are currently empty. That last property is what lets a re-import run without destroying hand-curated data such as movement lists and composer birth/death dates; disagreements are reported rather than applied. Entries are created as drafts, with publishing behind a separate flag.

Also ignore the CMA token and the regenerable graph/state artifacts. This repo is public, so a committed token would be immediately compromised.